### PR TITLE
Hide Monthly Bill until data is ready

### DIFF
--- a/ui/ui/app/components/home/bills/billsBarsView.html
+++ b/ui/ui/app/components/home/bills/billsBarsView.html
@@ -6,7 +6,7 @@
 			</uib-tab-heading>
 			<div class="panel panel-default" ng-if="billBarsActive == 1">
 				<div class="panel-body">
-					<nvd3 options="monthsBarsOptions" data="monthsBarsData" api="monthsAPI"></nvd3>
+					<nvd3 options="monthsBarsOptions" data="monthsBarsData" api="monthsAPI" ng-if="monthsBarsIsLoaded"></nvd3>
 				</div>
 			</div>
 		</uib-tab>

--- a/ui/ui/app/components/home/bills/billsBarsView.html
+++ b/ui/ui/app/components/home/bills/billsBarsView.html
@@ -7,6 +7,13 @@
 			<div class="panel panel-default" ng-if="billBarsActive == 1">
 				<div class="panel-body">
 					<nvd3 options="monthsBarsOptions" data="monthsBarsData" api="monthsAPI" ng-if="monthsBarsIsLoaded"></nvd3>
+					<div class="spinner" ng-show="!monthsBarsIsLoaded">
+						<div class="rect1"></div>
+						<div class="rect2"></div>
+						<div class="rect3"></div>
+						<div class="rect4"></div>
+						<div class="rect5"></div>
+					</div>
 				</div>
 			</div>
 		</uib-tab>

--- a/ui/ui/app/components/home/bills/billsCtrl.js
+++ b/ui/ui/app/components/home/bills/billsCtrl.js
@@ -92,6 +92,7 @@ angular.module('trackit.home')
             };
 
             $scope.monthsBarsData = [];
+            $scope.monthsBarsIsLoaded = false;
 
             // Retrieve the data from the model for AWS
             if ($scope.AWSkey) {
@@ -121,6 +122,7 @@ angular.module('trackit.home')
                         key: "AWS",
                         values: values
                     });
+                    $scope.monthsBarsIsLoaded = true;
                 })
             }
 
@@ -153,43 +155,6 @@ angular.module('trackit.home')
                 })
                 */
             }
-
-            $scope.monthsData = [
-                {
-                    key: "AWS",
-                    values: [
-                        {
-                            x: "2017-07",
-                            y: 84
-                        },
-                        {
-                            x: "2017-08",
-                            y: 21
-                        },
-                        {
-                            x: "2017-09",
-                            y: 42
-                        }
-                    ]
-                },
-                {
-                    key: "GCP",
-                    values: [
-                        {
-                            x: "2017-07",
-                            y: 42
-                        },
-                        {
-                            x: "2017-08",
-                            y: 84
-                        },
-                        {
-                            x: "2017-09",
-                            y: 21
-                        }
-                    ]
-                }
-            ];
 
             // Get bill total
             function getPieTotal(data) {


### PR DESCRIPTION
Fix issue #TRAC-552

Chart won't be displayed until data is available.
"No Data Available" will no longer be displayed while data is loading.