### PR TITLE
Fix link for Storage Treemap

### DIFF
--- a/ui/ui/app/app.js
+++ b/ui/ui/app/app.js
@@ -246,7 +246,7 @@ var trackit = angular.module('trackit', [
             })
             .state('app.treemap', {
                 url: "/app/treemap",
-                templateUrl: "/components/optimize/costestimation/partials/treemap-partial.html"
+                templateUrl: "/components/monitor/s3map/TreeMapView.html"
             })
             .state('app.automation', {
                 url: "/app/automation",


### PR DESCRIPTION
Storage Treemap was trying to load its template at wrong location, so the link in Storage Map wasn't working.
I updated the `templateUrl` in `app.js` to load the right file.