### PR TITLE
Fix: Link for Storage Treemap after UI re-organisation

### DIFF
--- a/ui/ui/app/app.js
+++ b/ui/ui/app/app.js
@@ -246,7 +246,7 @@ var trackit = angular.module('trackit', [
             })
             .state('app.treemap', {
                 url: "/app/treemap",
-                templateUrl: "/components/optimize/costestimation/partials/treemap-partial.html"
+                templateUrl: "/components/monitor/s3map/TreeMapView.html"
             })
             .state('app.automation', {
                 url: "/app/automation",


### PR DESCRIPTION
This implements @hug33k fix to make the link to storage treemap working again.